### PR TITLE
Feat/accounting date

### DIFF
--- a/src/components/Board.js
+++ b/src/components/Board.js
@@ -1,10 +1,12 @@
 import React from 'react'
 import { useUsersMe } from '../hooks/asana/useUsersMe.js'
 import BoardSection from './BoardSection.js'
-import { GidContext } from '../contexts/GidContext.js'
 import { useSections } from '../hooks/asana/useSections.js'
-import { DatelineContext } from '../contexts/DatelineContext.js'
 import { useDateline } from '../reducers/useDateline.js'
+import { useProportion } from '../reducers/useProportion.js'
+import { GidContext } from '../contexts/GidContext.js'
+import { DatelineContext } from '../contexts/DatelineContext.js'
+import { ProportionContext } from '../contexts/ProportionContext.js'
 
 const workspaceGid = process.env.REACT_APP_WORKSPACE_GID
 const projectGid = process.env.REACT_APP_PROJECT_GID
@@ -19,13 +21,10 @@ function Board() {
 		Object.assign(section, { key: section.gid })
 	)
 
-	const {
-		dateline,
-		proposeStartOn,
-		proposeDueOn,
-		appendAccountingTask,
-		deleteAccountingTask,
-	} = useDateline()
+	const { dateline, proposeStartOn, proposeDueOn } = useDateline()
+
+	const { accountingTasks, appendAccountingTask, deleteAccountingTask } =
+		useProportion()
 
 	return (
 		<GidContext.Provider
@@ -41,18 +40,24 @@ function Board() {
 					dateline,
 					proposeStartOn,
 					proposeDueOn,
-					appendAccountingTask,
-					deleteAccountingTask,
 				}}
 			>
-				<h1>Board</h1>
-				{isUsersMeFetching || isSectionsFetching ? (
-					<p>fetching...</p>
-				) : (
-					sectionList.map(section => (
-						<BoardSection key={section.key} section={section} />
-					))
-				)}
+				<ProportionContext.Provider
+					value={{
+						accountingTasks,
+						appendAccountingTask,
+						deleteAccountingTask,
+					}}
+				>
+					<h1>Board</h1>
+					{isUsersMeFetching || isSectionsFetching ? (
+						<p>fetching...</p>
+					) : (
+						sectionList.map(section => (
+							<BoardSection key={section.key} section={section} />
+						))
+					)}
+				</ProportionContext.Provider>
 			</DatelineContext.Provider>
 		</GidContext.Provider>
 	)

--- a/src/components/Board.js
+++ b/src/components/Board.js
@@ -19,7 +19,13 @@ function Board() {
 		Object.assign(section, { key: section.gid })
 	)
 
-	const { dateline, proposeStartOn, proposeDueOn } = useDateline()
+	const {
+		dateline,
+		proposeStartOn,
+		proposeDueOn,
+		appendAccountingTask,
+		deleteAccountingTask,
+	} = useDateline()
 
 	return (
 		<GidContext.Provider
@@ -35,6 +41,8 @@ function Board() {
 					dateline,
 					proposeStartOn,
 					proposeDueOn,
+					appendAccountingTask,
+					deleteAccountingTask,
 				}}
 			>
 				<h1>Board</h1>

--- a/src/components/BoardTasks.js
+++ b/src/components/BoardTasks.js
@@ -29,8 +29,13 @@ function BoardTasks({ tasks }) {
 				.map(task => task.gid),
 		[detailTasks]
 	)
-	const { dateline, proposeStartOn, proposeDueOn, appendAccountingTask } =
-		useContext(DatelineContext)
+	const {
+		dateline,
+		proposeStartOn,
+		proposeDueOn,
+		appendAccountingTask,
+		deleteAccountingTask,
+	} = useContext(DatelineContext)
 	const taskDateline = useCallback(({ start_on: startOn, due_on: dueOn }) => {
 		if (startOn && !dueOn) {
 			return { startOn, dueOn: startOn }
@@ -46,6 +51,7 @@ function BoardTasks({ tasks }) {
 
 		return taskDateline(task)
 	}
+
 	const handleCheckboxCheck = taskGid => {
 		const { startOn, dueOn } = getTaskDueDates(taskGid)
 		const timeStartOn = new Date(startOn).getTime()
@@ -61,6 +67,11 @@ function BoardTasks({ tasks }) {
 			}).filter(date => ACCOUNTING_DAYS.includes(new Date(date).getDay())),
 		})
 		checkCheckbox(taskGid)
+	}
+
+	const handleCheckboxUncheck = taskGid => {
+		deleteAccountingTask(taskGid)
+		uncheckCheckbox(taskGid)
 	}
 
 	useEffect(() => {
@@ -140,8 +151,8 @@ function BoardTasks({ tasks }) {
 										checked={checked}
 										disabled={disabled}
 										checkbox={task}
-										uncheckCheckbox={uncheckCheckbox}
 										checkCheckbox={handleCheckboxCheck}
+										uncheckCheckbox={handleCheckboxUncheck}
 									/>
 								</div>
 								{disabled || (

--- a/src/components/BoardTasks.js
+++ b/src/components/BoardTasks.js
@@ -154,8 +154,7 @@ function BoardTasks({ tasks }) {
 		return {
 			key: task.gid,
 			name: task.name,
-			startOn: task.start_on,
-			dueOn: task.due_on,
+			displayDueDate: `${startOn} ~ ${dueOn}`,
 			paddingLeft,
 			paddingRight,
 			customField,
@@ -196,11 +195,7 @@ function BoardTasks({ tasks }) {
 												opacity: checked ? 1 : 0.2,
 											}}
 										>
-											<div>
-												<span>{task.startOn}</span>
-												&nbsp;~&nbsp;
-												<span>{task.dueOn}</span>
-											</div>
+											<div>{task.displayDueDate}</div>
 											<div
 												style={{
 													paddingLeft: task.paddingLeft,

--- a/src/components/BoardTasks.js
+++ b/src/components/BoardTasks.js
@@ -99,6 +99,7 @@ function BoardTasks({ tasks }) {
 	}
 
 	const submitSuggestiveProportion = taskGid => {
+		// TODO: ajax client.tasks.updateTask
 		setTaskList(
 			taskList.map(task => {
 				if (task.gid !== taskGid) {

--- a/src/components/BoardTasks.js
+++ b/src/components/BoardTasks.js
@@ -98,6 +98,23 @@ function BoardTasks({ tasks }) {
 		uncheckCheckbox(taskGid)
 	}
 
+	const submitSuggestiveProportion = taskGid => {
+		setTaskList(
+			taskList.map(task => {
+				if (task.gid !== taskGid) {
+					return task
+				}
+				return {
+					...task,
+					customField: {
+						...task.customField,
+						displayValue: getSuggestiveProportion(task.gid),
+					},
+				}
+			})
+		)
+	}
+
 	return (
 		<>
 			{isFetching ? (
@@ -197,6 +214,9 @@ function BoardTasks({ tasks }) {
 												<Button
 													disabled={isSuggestiveDisabled}
 													style={{ width: '90%' }}
+													handleClick={() =>
+														submitSuggestiveProportion(task.gid)
+													}
 												>
 													{suggestiveProportion}
 												</Button>

--- a/src/components/BoardTasks.js
+++ b/src/components/BoardTasks.js
@@ -10,6 +10,7 @@ import {
 	getTimeDueOn,
 	getTimeStartOn,
 } from '../reducers/useDateline.js'
+import Button from './Button.js'
 
 const CUSTOM_FIELD_GID = process.env.REACT_APP_CUSTOM_FIELD_GID
 const ONE_DAY_TIME = 1000 * 60 * 60 * 24
@@ -234,17 +235,12 @@ function BoardTasks({ tasks }) {
 											}}
 										>
 											{checked && (
-												<button
+												<Button
 													disabled={task.customField.isSuggestiveDisabled}
-													style={{
-														width: '90%',
-														cursor: task.customField.isSuggestiveDisabled
-															? 'default'
-															: 'pointer',
-													}}
+													style={{ width: '90%' }}
 												>
 													{task.customField.suggestiveProportion}
-												</button>
+												</Button>
 											)}
 										</div>
 									</>

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -1,8 +1,13 @@
 import React from 'react'
 
-function Button({ handleClick, children, isDisabled }) {
+function Button({ handleClick, children, disabled }) {
 	return (
-		<button disabled={isDisabled} type="button" onClick={handleClick}>
+		<button
+			style={{ cursor: disabled ? 'default' : 'pointer' }}
+			disabled={disabled}
+			type="button"
+			onClick={handleClick}
+		>
 			{children}
 		</button>
 	)

--- a/src/components/Project.js
+++ b/src/components/Project.js
@@ -47,7 +47,7 @@ function Project({ updateProjectGid }) {
 					/>
 				</RadioList>
 			)}
-			<Button isDisabled={!checkedRadio} handleClick={handleClick}>
+			<Button disabled={!checkedRadio} handleClick={handleClick}>
 				confirm
 			</Button>
 		</>

--- a/src/components/RadioList.js
+++ b/src/components/RadioList.js
@@ -22,7 +22,9 @@ function RadioList({
 							checked={isChecked}
 							onChange={() => updateCurrentRadio(radio.key)}
 						/>
-						<label htmlFor={radio.key}>{radio.name}</label>
+						<label style={{ cursor: 'pointer' }} htmlFor={radio.key}>
+							{radio.name}
+						</label>
 						{isChecked && children}
 					</li>
 				)

--- a/src/components/Section.js
+++ b/src/components/Section.js
@@ -37,7 +37,7 @@ function Section({ updateTaskGids }) {
 					</div>
 				))
 			)}
-			<Button isDisabled={sectionList.length === 0} handleClick={handleClick}>
+			<Button disabled={sectionList.length === 0} handleClick={handleClick}>
 				confirm
 			</Button>
 		</>

--- a/src/components/Workspace.js
+++ b/src/components/Workspace.js
@@ -28,7 +28,7 @@ function Workspace({ updateWorkspaceGid }) {
 					updateCurrentRadio={updateRadio}
 				/>
 			)}
-			<Button isDisabled={!checkedRadio} handleClick={handleClick}>
+			<Button disabled={!checkedRadio} handleClick={handleClick}>
 				confirm
 			</Button>
 		</>

--- a/src/contexts/ProportionContext.js
+++ b/src/contexts/ProportionContext.js
@@ -1,0 +1,3 @@
+import { createContext } from 'react'
+
+export const ProportionContext = createContext(null)

--- a/src/reducers/useDateline.js
+++ b/src/reducers/useDateline.js
@@ -3,7 +3,6 @@ import { useReducer } from 'react'
 export const defaultDateline = {
 	startOn: null,
 	dueOn: null,
-	accountingTasks: [],
 }
 
 export function getTimeStartOn(startOn) {
@@ -64,18 +63,6 @@ const reducer = (state, action) => {
 			return dealStartOnDateline(state, action.startOn)
 		case 'due':
 			return dealDueOnDateline(state, action.dueOn)
-		case 'add':
-			return {
-				...state,
-				accountingTasks: state.accountingTasks.concat([action.task]),
-			}
-		case 'remove':
-			return {
-				...state,
-				accountingTasks: state.accountingTasks.filter(
-					task => task.gid !== action.taskGid
-				),
-			}
 		default:
 			return state
 	}
@@ -88,7 +75,5 @@ export function useDateline() {
 		dateline: state,
 		proposeStartOn: startOn => dispatch({ type: 'start', startOn }),
 		proposeDueOn: dueOn => dispatch({ type: 'due', dueOn }),
-		appendAccountingTask: task => dispatch({ type: 'add', task }),
-		deleteAccountingTask: taskGid => dispatch({ type: 'remove', taskGid }),
 	}
 }

--- a/src/reducers/useDateline.js
+++ b/src/reducers/useDateline.js
@@ -73,7 +73,7 @@ const reducer = (state, action) => {
 			return {
 				...state,
 				accountingTasks: state.accountingTasks.filter(
-					task => task.gid !== action.task.gid
+					task => task.gid !== action.taskGid
 				),
 			}
 		default:
@@ -89,6 +89,6 @@ export function useDateline() {
 		proposeStartOn: startOn => dispatch({ type: 'start', startOn }),
 		proposeDueOn: dueOn => dispatch({ type: 'due', dueOn }),
 		appendAccountingTask: task => dispatch({ type: 'add', task }),
-		deleteAccountingTask: task => dispatch({ type: 'remove', task }),
+		deleteAccountingTask: taskGid => dispatch({ type: 'remove', taskGid }),
 	}
 }

--- a/src/reducers/useDateline.js
+++ b/src/reducers/useDateline.js
@@ -1,6 +1,10 @@
 import { useReducer } from 'react'
 
-export const defaultDateline = { startOn: null, dueOn: null }
+export const defaultDateline = {
+	startOn: null,
+	dueOn: null,
+	accountingTasks: [],
+}
 
 export function getTimeStartOn(startOn) {
 	const dateStartOn = new Date(startOn)
@@ -60,6 +64,18 @@ const reducer = (state, action) => {
 			return dealStartOnDateline(state, action.startOn)
 		case 'due':
 			return dealDueOnDateline(state, action.dueOn)
+		case 'add':
+			return {
+				...state,
+				accountingTasks: state.accountingTasks.concat([action.task]),
+			}
+		case 'remove':
+			return {
+				...state,
+				accountingTasks: state.accountingTasks.filter(
+					task => task.gid !== action.task.gid
+				),
+			}
 		default:
 			return state
 	}
@@ -72,5 +88,7 @@ export function useDateline() {
 		dateline: state,
 		proposeStartOn: startOn => dispatch({ type: 'start', startOn }),
 		proposeDueOn: dueOn => dispatch({ type: 'due', dueOn }),
+		appendAccountingTask: task => dispatch({ type: 'add', task }),
+		deleteAccountingTask: task => dispatch({ type: 'remove', task }),
 	}
 }

--- a/src/reducers/useProportion.js
+++ b/src/reducers/useProportion.js
@@ -1,0 +1,64 @@
+import { useReducer } from 'react'
+
+const ONE_DAY_TIME = 1000 * 60 * 60 * 24
+const ACCOUNTING_DAYS = [1, 2, 3, 5]
+
+function getAccountingTask(task) {
+	const { gid, startOn, dueOn } = task
+	const timeStartOn = new Date(startOn).getTime()
+	const timeDueOn = new Date(dueOn).getTime()
+	const dayCount = Math.round((timeDueOn - timeStartOn) / ONE_DAY_TIME)
+
+	return {
+		gid,
+		dates: Array.from(Array(dayCount).keys(), index => {
+			const date = new Date(startOn)
+			date.setDate(date.getDate() + index)
+			return date.toISOString().slice(0, 10)
+		}).filter(date => ACCOUNTING_DAYS.includes(new Date(date).getDay())),
+	}
+}
+
+function updatedProportionTasks(accountingTasks) {
+	const accountingTaskCount = date => {
+		return accountingTasks.reduce(
+			(total, task) => (task.dates.includes(date) ? total + 1 : total),
+			0
+		)
+	}
+
+	return accountingTasks.map(task => {
+		const totalProportion = task.dates.reduce((total, date) => {
+			const proportion = 1 / accountingTaskCount(date)
+
+			return total + proportion
+		}, 0)
+		return {
+			...task,
+			proportion: totalProportion.toFixed(2),
+		}
+	})
+}
+
+const reducer = (state, action) => {
+	switch (action.type) {
+		case 'add':
+			return updatedProportionTasks([...state, getAccountingTask(action.task)])
+		case 'remove':
+			return updatedProportionTasks(
+				state.filter(task => task.gid !== action.taskGid)
+			)
+		default:
+			return state
+	}
+}
+
+export function useProportion() {
+	const [state, dispatch] = useReducer(reducer, [], state => state)
+
+	return {
+		accountingTasks: state,
+		appendAccountingTask: task => dispatch({ type: 'add', task }),
+		deleteAccountingTask: taskGid => dispatch({ type: 'remove', taskGid }),
+	}
+}


### PR DESCRIPTION
新增
- radio input cursor pointer
- hooks `ProportionContext`, `useProportion` 負責計算推薦估時
- 提交推薦按鈕 function 供未來接 api client.tasks.updateTask 使用

重構
> 資料流為 detailTasks -> taskList -> render

- detailTasks 保持負責 api 資料
  - 取得資料後更新 dateline 記錄的 startOn & dueOn
- taskList 轉換應用的資料格式
  - 更新 startOn & dueOn 缺值 & 提出單一 customField
- render 將顯示資料整理
  - 顯示 due date 的區間
  - 拿出 proportion hooks 計算的推薦估時 & 決定是否 disabled
  - 拿出 dateline hooks 轉換時間區間的 padding