### PR TITLE
Feat/submit task

### DIFF
--- a/src/hooks/asana/asana.js
+++ b/src/hooks/asana/asana.js
@@ -46,6 +46,39 @@ export async function fetchTasks(workspaceGid, assigneeGid, sectionGid) {
 	return { tasks }
 }
 
+export async function updateAsanaTaskCustomField({
+	taskGid,
+	customFieldGid,
+	customFieldValue,
+}) {
+	const response = await client.tasks.updateTask(taskGid, {
+		custom_fields: {
+			[customFieldGid]: customFieldValue,
+		},
+	})
+	// const response = {
+	// 	custom_fields: [
+	// 		{
+	// 			gid: '1201939511159645',
+	// 			resource_type: 'custom_field',
+	// 			resource_subtype: 'number',
+	// 			type: 'number',
+	// 			name: '估時(天)',
+	// 			enabled: true,
+	// 			precision: 2,
+	// 			number_value: 8,
+	// 			display_value: '8',
+	// 			created_by: {
+	// 				gid: '504260977666421',
+	// 				resource_type: 'user',
+	// 				name: 'Danny Lin',
+	// 			},
+	// 		},
+	// 	],
+	// }
+	return response
+}
+
 export const fetch = async () => {
 	const { assigneeGid, workspaceGid } = await fetchMe()
 	const projectGid = await fetchProjects(workspaceGid)

--- a/src/reducers/useProportion.js
+++ b/src/reducers/useProportion.js
@@ -3,6 +3,10 @@ import { useReducer } from 'react'
 const ONE_DAY_TIME = 1000 * 60 * 60 * 24
 const ACCOUNTING_DAYS = [1, 2, 3, 5]
 
+export function formatProportion(proportion) {
+	return proportion.toFixed(2)
+}
+
 function getAccountingTask(task) {
 	const { gid, startOn, dueOn } = task
 	const timeStartOn = new Date(startOn).getTime()
@@ -35,7 +39,7 @@ function updatedProportionTasks(accountingTasks) {
 		}, 0)
 		return {
 			...task,
-			proportion: totalProportion.toFixed(2),
+			proportion: formatProportion(totalProportion),
 		}
 	})
 }


### PR DESCRIPTION
重構
- 拉出 `formatProportion` method 保持估時顯示格式一致

新增
- 按鈕點擊送出 `client.tasks.updateTask` API 更新
- 按鈕點擊的 loading 狀態
- 更新後的成功/失敗 alert