### PR TITLE
Feat/demo route

### DIFF
--- a/src/About.js
+++ b/src/About.js
@@ -1,5 +1,0 @@
-import React from 'react'
-
-const About = () => <div>about</div>
-
-export default About

--- a/src/App.js
+++ b/src/App.js
@@ -1,88 +1,16 @@
 import './App.css'
-import { Link, Route, Routes, useNavigate } from 'react-router-dom'
-import { useState } from 'react'
-import Workspace from './components/Workspace'
-import Project from './components/Project'
-import Section from './components/Section'
-import Task from './components/Task.js'
+import { Route, Routes } from 'react-router-dom'
 import Board from './components/Board.js'
-import Home from './Home'
-import { GidContext } from './contexts/GidContext.js'
+import Demo from './components/Demo.js'
 
 function App() {
-	const navigate = useNavigate()
-
-	const [assigneeGid, setAssigneeGid] = useState('')
-	const [workspaceGid, setWorkspaceGid] = useState('')
-	const updateWorkspaceGid = (assigneeGid, workspaceGid) => {
-		setAssigneeGid(assigneeGid)
-		setWorkspaceGid(workspaceGid)
-		navigate('/project')
-	}
-
-	const [projectGid, setProjectGid] = useState('')
-	const [customFieldGids, setCustomFieldGids] = useState([])
-	const updateProjectGid = (projectGid, customFieldGids) => {
-		setProjectGid(projectGid)
-		setCustomFieldGids(customFieldGids)
-		navigate('/section')
-	}
-
-	const [taskGids, setTaskGids] = useState([])
-	const updateTaskGids = gids => {
-		setTaskGids(gids)
-		navigate('/task')
-	}
-
 	return (
 		<div className="App">
-			<nav>
-				<ul style={{ display: 'flex' }}>
-					<li style={{ listStyleType: 'none', paddingRight: '8px' }}>
-						<Link to="/workspace">Workspace</Link>
-					</li>
-					<li style={{ listStyleType: 'none', paddingRight: '8px' }}>
-						<Link to="/project">Project</Link>
-					</li>
-					<li style={{ listStyleType: 'none', paddingRight: '8px' }}>
-						<Link to="/section">Section</Link>
-					</li>
-					<li style={{ listStyleType: 'none', paddingRight: '8px' }}>
-						<Link to="/task">Task</Link>
-					</li>
-					<li style={{ listStyleType: 'none', paddingRight: '8px' }}>
-						<Link to="/board">Board</Link>
-					</li>
-				</ul>
-			</nav>
-			<GidContext.Provider
-				value={{
-					assigneeGid,
-					workspaceGid,
-					projectGid,
-					customFieldGids,
-					taskGids,
-				}}
-			>
-				<Routes>
-					<Route
-						path="/workspace"
-						element={<Workspace updateWorkspaceGid={updateWorkspaceGid} />}
-					/>
-					<Route
-						path="/project"
-						element={<Project updateProjectGid={updateProjectGid} />}
-					/>
-					<Route
-						path="/section"
-						element={<Section updateTaskGids={updateTaskGids} />}
-					/>
-					<Route path="/task" element={<Task />} />
-					<Route path="/board" element={<Board />} />
-					<Route path="/" element={<Home />} />
-					{projectGid}
-				</Routes>
-			</GidContext.Provider>
+			<Routes>
+				<Route path="/demo/*" element={<Demo path={'/demo'} />} />
+				<Route path="/board" element={<Board />} />
+				<Route path="/" element={<Board />} />
+			</Routes>
 		</div>
 	)
 }

--- a/src/Home.js
+++ b/src/Home.js
@@ -1,7 +1,0 @@
-import React from 'react'
-
-function Home() {
-	return <div>home</div>
-}
-
-export default Home

--- a/src/Users.js
+++ b/src/Users.js
@@ -1,5 +1,0 @@
-import React from 'react'
-
-const Users = () => <div>users</div>
-
-export default Users

--- a/src/components/Board.js
+++ b/src/components/Board.js
@@ -7,6 +7,7 @@ import { useProportion } from '../reducers/useProportion.js'
 import { GidContext } from '../contexts/GidContext.js'
 import { DatelineContext } from '../contexts/DatelineContext.js'
 import { ProportionContext } from '../contexts/ProportionContext.js'
+import { NavLink } from 'react-router-dom'
 
 const workspaceGid = process.env.REACT_APP_WORKSPACE_GID
 const projectGid = process.env.REACT_APP_PROJECT_GID
@@ -27,39 +28,57 @@ function Board() {
 		useProportion()
 
 	return (
-		<GidContext.Provider
-			value={{
-				workspaceGid,
-				projectGid,
-				customFieldGids,
-				assigneeGid,
-			}}
-		>
-			<DatelineContext.Provider
-				value={{
-					dateline,
-					proposeStartOn,
-					proposeDueOn,
+		<>
+			<nav
+				style={{
+					display: 'flex',
+					direction: 'revert',
+					justifyContent: 'right',
 				}}
 			>
-				<ProportionContext.Provider
+				<NavLink
+					to="/demo"
+					style={({ isActive }) => ({
+						color: isActive ? 'grey' : 'inherit',
+					})}
+				>
+					Demo
+				</NavLink>
+			</nav>
+			<GidContext.Provider
+				value={{
+					workspaceGid,
+					projectGid,
+					customFieldGids,
+					assigneeGid,
+				}}
+			>
+				<DatelineContext.Provider
 					value={{
-						accountingTasks,
-						appendAccountingTask,
-						deleteAccountingTask,
+						dateline,
+						proposeStartOn,
+						proposeDueOn,
 					}}
 				>
-					<h1>Board</h1>
-					{isUsersMeFetching || isSectionsFetching ? (
-						<p>fetching...</p>
-					) : (
-						sectionList.map(section => (
-							<BoardSection key={section.key} section={section} />
-						))
-					)}
-				</ProportionContext.Provider>
-			</DatelineContext.Provider>
-		</GidContext.Provider>
+					<ProportionContext.Provider
+						value={{
+							accountingTasks,
+							appendAccountingTask,
+							deleteAccountingTask,
+						}}
+					>
+						<h1>Board</h1>
+						{isUsersMeFetching || isSectionsFetching ? (
+							<p>fetching...</p>
+						) : (
+							sectionList.map(section => (
+								<BoardSection key={section.key} section={section} />
+							))
+						)}
+					</ProportionContext.Provider>
+				</DatelineContext.Provider>
+			</GidContext.Provider>
+		</>
 	)
 }
 

--- a/src/components/Demo.js
+++ b/src/components/Demo.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { Link, Route, Routes, useLocation, useNavigate } from 'react-router-dom'
+import { NavLink, Route, Routes, useNavigate } from 'react-router-dom'
 import { GidContext } from '../contexts/GidContext.js'
 import Workspace from './Workspace'
 import Project from './Project'
@@ -9,8 +9,6 @@ import Task from './Task.js'
 function Demo({ path }) {
 	const navigate = useNavigate()
 
-	const locationStateLocation = useLocation()
-	console.log('locationStateLocation', locationStateLocation)
 	const [assigneeGid, setAssigneeGid] = useState('')
 	const [workspaceGid, setWorkspaceGid] = useState('')
 	const updateWorkspaceGid = (assigneeGid, workspaceGid) => {
@@ -34,52 +32,84 @@ function Demo({ path }) {
 	}
 
 	return (
-		<div>
-			<GidContext.Provider
-				value={{
-					assigneeGid,
-					workspaceGid,
-					projectGid,
-					customFieldGids,
-					taskGids,
-				}}
-			>
-				<nav>
-					<ul style={{ display: 'flex' }}>
-						<li style={{ listStyleType: 'none', paddingRight: '8px' }}>
-							<Link to={`${path}/workspace`}>Workspace</Link>
-						</li>
-						<li style={{ listStyleType: 'none', paddingRight: '8px' }}>
-							<Link to={`${path}/project`}>Project</Link>
-						</li>
-						<li style={{ listStyleType: 'none', paddingRight: '8px' }}>
-							<Link to={`${path}/section`}>Section</Link>
-						</li>
-						<li style={{ listStyleType: 'none', paddingRight: '8px' }}>
-							<Link to={`${path}/task`}>Task</Link>
-						</li>
-						<li style={{ listStyleType: 'none', paddingRight: '8px' }}>
-							<Link to="/board">Board</Link>
-						</li>
-					</ul>
-				</nav>
-				<Routes>
-					<Route
-						path="/workspace"
-						element={<Workspace updateWorkspaceGid={updateWorkspaceGid} />}
-					/>
-					<Route
-						path="/project"
-						element={<Project updateProjectGid={updateProjectGid} />}
-					/>
-					<Route
-						path="/section"
-						element={<Section updateTaskGids={updateTaskGids} />}
-					/>
-					<Route path="/task" element={<Task />} />)
-				</Routes>
-			</GidContext.Provider>
-		</div>
+		<GidContext.Provider
+			value={{
+				assigneeGid,
+				workspaceGid,
+				projectGid,
+				customFieldGids,
+				taskGids,
+			}}
+		>
+			<nav style={{ display: 'flex', justifyContent: 'space-between' }}>
+				<ul style={{ display: 'grid', gap: '4px', margin: 0, padding: 0 }}>
+					<li style={{ listStyleType: 'none', paddingRight: '8px' }}>
+						<NavLink
+							to={`${path}/workspace`}
+							style={({ isActive }) => ({
+								color: isActive ? 'grey' : 'inherit',
+							})}
+						>
+							Step 1. Workspace
+						</NavLink>
+					</li>
+					<li style={{ listStyleType: 'none', paddingRight: '8px' }}>
+						<NavLink
+							to={`${path}/project`}
+							style={({ isActive }) => ({
+								color: isActive ? 'grey' : 'inherit',
+							})}
+						>
+							Step 2. Project
+						</NavLink>
+					</li>
+					<li style={{ listStyleType: 'none', paddingRight: '8px' }}>
+						<NavLink
+							to={`${path}/section`}
+							style={({ isActive }) => ({
+								color: isActive ? 'grey' : 'inherit',
+							})}
+						>
+							Step 3. Section
+						</NavLink>
+					</li>
+					<li style={{ listStyleType: 'none', paddingRight: '8px' }}>
+						<NavLink
+							to={`${path}/task`}
+							style={({ isActive }) => ({
+								color: isActive ? 'grey' : 'inherit',
+							})}
+						>
+							Step 4. Task
+						</NavLink>
+					</li>
+					<li style={{ listStyleType: 'none', paddingRight: '8px' }}></li>
+				</ul>
+				<NavLink
+					to="/board"
+					style={({ isActive }) => ({
+						color: isActive ? 'grey' : 'inherit',
+					})}
+				>
+					Board
+				</NavLink>
+			</nav>
+			<Routes>
+				<Route
+					path="/workspace"
+					element={<Workspace updateWorkspaceGid={updateWorkspaceGid} />}
+				/>
+				<Route
+					path="/project"
+					element={<Project updateProjectGid={updateProjectGid} />}
+				/>
+				<Route
+					path="/section"
+					element={<Section updateTaskGids={updateTaskGids} />}
+				/>
+				<Route path="/task" element={<Task />} />)
+			</Routes>
+		</GidContext.Provider>
 	)
 }
 

--- a/src/components/Demo.js
+++ b/src/components/Demo.js
@@ -1,0 +1,86 @@
+import React, { useState } from 'react'
+import { Link, Route, Routes, useLocation, useNavigate } from 'react-router-dom'
+import { GidContext } from '../contexts/GidContext.js'
+import Workspace from './Workspace'
+import Project from './Project'
+import Section from './Section'
+import Task from './Task.js'
+
+function Demo({ path }) {
+	const navigate = useNavigate()
+
+	const locationStateLocation = useLocation()
+	console.log('locationStateLocation', locationStateLocation)
+	const [assigneeGid, setAssigneeGid] = useState('')
+	const [workspaceGid, setWorkspaceGid] = useState('')
+	const updateWorkspaceGid = (assigneeGid, workspaceGid) => {
+		setAssigneeGid(assigneeGid)
+		setWorkspaceGid(workspaceGid)
+		navigate(`${path}/project`)
+	}
+
+	const [projectGid, setProjectGid] = useState('')
+	const [customFieldGids, setCustomFieldGids] = useState([])
+	const updateProjectGid = (projectGid, customFieldGids) => {
+		setProjectGid(projectGid)
+		setCustomFieldGids(customFieldGids)
+		navigate(`${path}/section`)
+	}
+
+	const [taskGids, setTaskGids] = useState([])
+	const updateTaskGids = gids => {
+		setTaskGids(gids)
+		navigate(`${path}/task`)
+	}
+
+	return (
+		<div>
+			<GidContext.Provider
+				value={{
+					assigneeGid,
+					workspaceGid,
+					projectGid,
+					customFieldGids,
+					taskGids,
+				}}
+			>
+				<nav>
+					<ul style={{ display: 'flex' }}>
+						<li style={{ listStyleType: 'none', paddingRight: '8px' }}>
+							<Link to={`${path}/workspace`}>Workspace</Link>
+						</li>
+						<li style={{ listStyleType: 'none', paddingRight: '8px' }}>
+							<Link to={`${path}/project`}>Project</Link>
+						</li>
+						<li style={{ listStyleType: 'none', paddingRight: '8px' }}>
+							<Link to={`${path}/section`}>Section</Link>
+						</li>
+						<li style={{ listStyleType: 'none', paddingRight: '8px' }}>
+							<Link to={`${path}/task`}>Task</Link>
+						</li>
+						<li style={{ listStyleType: 'none', paddingRight: '8px' }}>
+							<Link to="/board">Board</Link>
+						</li>
+					</ul>
+				</nav>
+				<Routes>
+					<Route
+						path="/workspace"
+						element={<Workspace updateWorkspaceGid={updateWorkspaceGid} />}
+					/>
+					<Route
+						path="/project"
+						element={<Project updateProjectGid={updateProjectGid} />}
+					/>
+					<Route
+						path="/section"
+						element={<Section updateTaskGids={updateTaskGids} />}
+					/>
+					<Route path="/task" element={<Task />} />)
+				</Routes>
+			</GidContext.Provider>
+		</div>
+	)
+}
+
+export default Demo

--- a/src/components/Section.js
+++ b/src/components/Section.js
@@ -19,7 +19,7 @@ function Section({ updateTaskGids }) {
 
 	return (
 		<>
-			<h1>Section</h1>
+			<h1>Sections</h1>
 			{isFetching ? (
 				<p>fetching...</p>
 			) : (

--- a/src/components/Task.js
+++ b/src/components/Task.js
@@ -32,7 +32,7 @@ function Task() {
 
 	return (
 		<>
-			<h1>Task</h1>
+			<h1>Tasks</h1>
 			{isFetching ? (
 				<p>fetching...</p>
 			) : (


### PR DESCRIPTION
### 目的
將 demo  & board 的 routes 區分開來
- demo
  - workspace
  - project
  - section
  - task
- board

### 調整
- 新增 child route 在 `/demo` 底下
- 刪除用不到的 route & component
- 使用 `NavLink` 取代 `Link` 顯示 active 的樣式

