### PR TITLE
Feat/update task refresh token

### DIFF
--- a/client/src/components/Board.js
+++ b/client/src/components/Board.js
@@ -1,5 +1,4 @@
-import React from 'react'
-import { useUsersMe } from '../hooks/asana/useUsersMe.js'
+import React, { useContext } from 'react'
 import BoardSection from './BoardSection.js'
 import { useSections } from '../hooks/asana/useSections.js'
 import { useDateline } from '../reducers/useDateline.js'
@@ -13,9 +12,10 @@ import {
 	PROJECT_GID as projectGid,
 	CUSTOM_FIELD_GID as customFieldGid,
 } from '../configs/constent.js'
+import { ClientContext } from '../contexts/ClientContext.js'
 
 function Board() {
-	const { isFetching: isUsersMeFetching, meGid: assigneeGid } = useUsersMe()
+	const { user } = useContext(ClientContext)
 	const { isFetching: isSectionsFetching, sections } = useSections({
 		projectGid,
 	})
@@ -34,7 +34,7 @@ function Board() {
 				workspaceGid,
 				projectGid,
 				customFieldGids: [customFieldGid],
-				assigneeGid,
+				assigneeGid: user.gid,
 			}}
 		>
 			<DatelineContext.Provider
@@ -69,7 +69,7 @@ function Board() {
 							</NavLink>
 						</nav>
 					</div>
-					{isUsersMeFetching || isSectionsFetching ? (
+					{user.isFetching || isSectionsFetching ? (
 						<p>fetching...</p>
 					) : (
 						sectionList.map(section => (

--- a/client/src/components/BoardTasks.js
+++ b/client/src/components/BoardTasks.js
@@ -106,7 +106,7 @@ function BoardTasks({ tasks }) {
 		uncheckCheckbox(taskGid)
 	}
 
-	const { client } = useContext(ClientContext)
+	const { client, fetchOauthToken } = useContext(ClientContext)
 	const updateAsanaTaskCustomField = useCallback(
 		async ({ taskGid, customFieldGid, customFieldValue }) => {
 			const response = await client.tasks.updateTask(taskGid, {
@@ -130,6 +130,11 @@ function BoardTasks({ tasks }) {
 			)
 		}
 
+		const handleRefreshToken = async () => {
+			await fetchOauthToken()
+			submitSuggestiveProportion(task)
+		}
+
 		try {
 			updateButtonLoading(true)
 			const suggestiveProportion = getSuggestiveProportion(taskGid)
@@ -150,11 +155,14 @@ function BoardTasks({ tasks }) {
 					return task
 				})
 			)
-		} catch (e) {
-			alert(`update "${taskName}" unsuccessfully`)
-			console.error(e)
-		} finally {
 			updateButtonLoading(false)
+		} catch (e) {
+			if (e.status === 401) {
+				handleRefreshToken()
+			} else {
+				console.error(e)
+				updateButtonLoading(false)
+			}
 		}
 	}
 

--- a/client/src/components/oauth/Authorization.js
+++ b/client/src/components/oauth/Authorization.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useCallback, useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import asana from 'asana'
 import { ClientContext } from '../../contexts/ClientContext.js'
@@ -8,41 +8,68 @@ function Authorization({ children }) {
 	const [client, setClient] = useState(null)
 	const [user, setUser] = useState({})
 
+	const fetchOauthToken = async () => {
+		fetch('/oauth_token', {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+			},
+			body: JSON.stringify({
+				refresh_token: localStorage.getItem('refresh_token'),
+				grant_type: 'refresh_token',
+			}),
+		})
+			.then(response => response.json())
+			.then(({ access_token }) => {
+				if (!access_token) {
+					throw new Error('did not fetch the access token')
+				}
+				localStorage.setItem('access_token', access_token)
+				const client = asana.Client.create().useAccessToken(access_token)
+				setClient(client)
+			})
+			.catch(e => {
+				alert(e)
+			})
+	}
+
+	const fetchMe = useCallback(async () => {
+		try {
+			setUser({ isFetching: true })
+			const { gid = '', email = '', name = '' } = await client.users.me()
+
+			setUser({ gid, email, name, isFetching: false })
+		} catch (e) {
+			alert(e)
+			if (localStorage.getItem('refresh_token')) {
+				navigate('/oauth/refresh')
+			} else {
+				navigate('/oauth/grant')
+			}
+		}
+	}, [client])
+
 	useEffect(() => {
 		const accessToken = localStorage.getItem('access_token')
-		const refreshToken = localStorage.getItem('refresh_token')
 
 		if (!accessToken) {
 			navigate('/oauth/grant')
+			return
 		}
 
-		const fetchMe = async () => {
-			try {
-				setUser({ isFetching: true })
-
-				const client = asana.Client.create().useAccessToken(accessToken)
-				const { gid = '', email = '', name = '' } = await client.users.me()
-
-				setUser({ gid, email, name, isFetching: false })
-				setClient(client)
-			} catch (e) {
-				setUser({ isFetching: false })
-				alert(e)
-				localStorage.removeItem('access_token')
-				if (refreshToken) {
-					navigate('/oauth/refresh')
-				} else {
-					navigate('/oauth/grant')
-				}
-			}
-		}
-
-		fetchMe()
+		const client = asana.Client.create().useAccessToken(accessToken)
+		setClient(client)
 	}, [])
 
+	useEffect(() => {
+		if (!client) return
+
+		fetchMe()
+	}, [client])
+
 	return (
-		<ClientContext.Provider value={{ client, user }}>
-			{children}
+		<ClientContext.Provider value={{ client, user, fetchOauthToken }}>
+			{client && children}
 		</ClientContext.Provider>
 	)
 }

--- a/client/src/components/oauth/Authorization.js
+++ b/client/src/components/oauth/Authorization.js
@@ -10,7 +10,7 @@ function Authorization({ children }) {
 	const isUserSet = useRef(false)
 
 	const fetchOauthToken = async () => {
-		fetch('/oauth_token', {
+		await fetch('/oauth_token', {
 			method: 'POST',
 			headers: {
 				'Content-Type': 'application/json',

--- a/client/src/components/oauth/Authorization.js
+++ b/client/src/components/oauth/Authorization.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import asana from 'asana'
 import { ClientContext } from '../../contexts/ClientContext.js'
@@ -7,6 +7,7 @@ function Authorization({ children }) {
 	const navigate = useNavigate()
 	const [client, setClient] = useState(null)
 	const [user, setUser] = useState({})
+	const isUserSet = useRef(false)
 
 	const fetchOauthToken = async () => {
 		fetch('/oauth_token', {
@@ -62,9 +63,10 @@ function Authorization({ children }) {
 	}, [])
 
 	useEffect(() => {
-		if (!client) return
+		if (!client || isUserSet.current) return
 
 		fetchMe()
+		isUserSet.current = true
 	}, [client])
 
 	return (

--- a/client/src/hooks/asana/useCustomFields.js
+++ b/client/src/hooks/asana/useCustomFields.js
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useState } from 'react'
+import { useCallback, useContext, useEffect, useState } from 'react'
 import { ClientContext } from '../../contexts/ClientContext.js'
 
 export function useCustomFields({ projectGid }) {
@@ -6,32 +6,35 @@ export function useCustomFields({ projectGid }) {
 	const [isFetching, setIsFetching] = useState(false)
 	const { client } = useContext(ClientContext)
 
-	async function fetchCustomFields(project) {
-		try {
-			setIsFetching(true)
-			const { data: customFieldSettings = [] } =
-				await client.customFieldSettings.getCustomFieldSettingsForProject(
-					project,
-					{}
-				)
+	const fetchCustomFields = useCallback(
+		async project => {
+			try {
+				setIsFetching(true)
+				const { data: customFieldSettings = [] } =
+					await client.customFieldSettings.getCustomFieldSettingsForProject(
+						project,
+						{}
+					)
 
-			setCustomFields(
-				customFieldSettings.map(
-					customFieldSetting => customFieldSetting.custom_field
+				setCustomFields(
+					customFieldSettings.map(
+						customFieldSetting => customFieldSetting.custom_field
+					)
 				)
-			)
-		} catch (e) {
-			console.error(e)
-		} finally {
-			setIsFetching(false)
-		}
-	}
+			} catch (e) {
+				console.error(e)
+			} finally {
+				setIsFetching(false)
+			}
+		},
+		[client]
+	)
 
 	useEffect(() => {
-		if (!projectGid || !client) return
+		if (!projectGid) return
 
 		fetchCustomFields(projectGid)
-	}, [projectGid, client])
+	}, [projectGid])
 
 	return { isFetching, customFields }
 }

--- a/client/src/hooks/asana/useDetailTasks.js
+++ b/client/src/hooks/asana/useDetailTasks.js
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useState } from 'react'
+import { useCallback, useContext, useEffect, useState } from 'react'
 import { ClientContext } from '../../contexts/ClientContext.js'
 
 export function useDetailTasks({ taskGids }) {
@@ -6,25 +6,28 @@ export function useDetailTasks({ taskGids }) {
 	const [isFetching, setIsFetching] = useState(false)
 	const { client } = useContext(ClientContext)
 
-	async function fetchDetailTasks(tasks) {
-		try {
-			setIsFetching(true)
-			const promises = tasks.map(task => client.tasks.getTask(task, {}))
-			const detailTasks = await Promise.all(promises)
+	const fetchDetailTasks = useCallback(
+		async tasks => {
+			try {
+				setIsFetching(true)
+				const promises = tasks.map(task => client.tasks.getTask(task, {}))
+				const detailTasks = await Promise.all(promises)
 
-			setDetailTasks(detailTasks)
-		} catch (e) {
-			console.error(e)
-		} finally {
-			setIsFetching(false)
-		}
-	}
+				setDetailTasks(detailTasks)
+			} catch (e) {
+				console.error(e)
+			} finally {
+				setIsFetching(false)
+			}
+		},
+		[client]
+	)
 
 	useEffect(() => {
-		if (taskGids.length === 0 || !client) return
+		if (taskGids.length === 0) return
 
 		fetchDetailTasks(taskGids)
-	}, [taskGids, client])
+	}, [taskGids])
 
 	return { isFetching, detailTasks }
 }

--- a/client/src/hooks/asana/useProjects.js
+++ b/client/src/hooks/asana/useProjects.js
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useState } from 'react'
+import { useCallback, useContext, useEffect, useState } from 'react'
 import { ClientContext } from '../../contexts/ClientContext.js'
 
 export function useProjects({ workspaceGid }) {
@@ -6,26 +6,29 @@ export function useProjects({ workspaceGid }) {
 	const [isFetching, setIsFetching] = useState(false)
 	const { client } = useContext(ClientContext)
 
-	async function fetchProjects(workspace) {
-		try {
-			setIsFetching(true)
-			const { data: projects = [] } = await client.projects.getProjects({
-				workspace,
-			})
+	const fetchProjects = useCallback(
+		async workspace => {
+			try {
+				setIsFetching(true)
+				const { data: projects = [] } = await client.projects.getProjects({
+					workspace,
+				})
 
-			setProjects(projects)
-		} catch (e) {
-			console.error(e)
-		} finally {
-			setIsFetching(false)
-		}
-	}
+				setProjects(projects)
+			} catch (e) {
+				console.error(e)
+			} finally {
+				setIsFetching(false)
+			}
+		},
+		[client]
+	)
 
 	useEffect(() => {
-		if (!workspaceGid || !client) return
+		if (!workspaceGid) return
 
 		fetchProjects(workspaceGid)
-	}, [workspaceGid, client])
+	}, [workspaceGid])
 
 	return { isFetching, projects }
 }

--- a/client/src/hooks/asana/useSections.js
+++ b/client/src/hooks/asana/useSections.js
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useState } from 'react'
+import { useCallback, useContext, useEffect, useState } from 'react'
 import { ClientContext } from '../../contexts/ClientContext.js'
 
 export function useSections({ projectGid }) {
@@ -6,25 +6,28 @@ export function useSections({ projectGid }) {
 	const [isFetching, setIsFetching] = useState(false)
 	const { client } = useContext(ClientContext)
 
-	async function fetchSections(project) {
-		try {
-			setIsFetching(true)
-			const { data: sections = [] } =
-				await client.sections.getSectionsForProject(project, {})
+	const fetchSections = useCallback(
+		async project => {
+			try {
+				setIsFetching(true)
+				const { data: sections = [] } =
+					await client.sections.getSectionsForProject(project, {})
 
-			setSections(sections)
-		} catch (e) {
-			console.error(e)
-		} finally {
-			setIsFetching(false)
-		}
-	}
+				setSections(sections)
+			} catch (e) {
+				console.error(e)
+			} finally {
+				setIsFetching(false)
+			}
+		},
+		[client]
+	)
 
 	useEffect(() => {
-		if (!projectGid || !client) return
+		if (!projectGid) return
 
 		fetchSections(projectGid)
-	}, [projectGid, client])
+	}, [projectGid])
 
 	return { isFetching, sections }
 }

--- a/client/src/hooks/asana/useTasks.js
+++ b/client/src/hooks/asana/useTasks.js
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useState } from 'react'
+import { useCallback, useContext, useEffect, useState } from 'react'
 import { ClientContext } from '../../contexts/ClientContext.js'
 
 export function useTasks({ workspaceGid, assigneeGid, sectionGid }) {
@@ -6,31 +6,34 @@ export function useTasks({ workspaceGid, assigneeGid, sectionGid }) {
 	const [isFetching, setIsFetching] = useState(false)
 	const { client } = useContext(ClientContext)
 
-	async function fetchTasks(workspace, assignee, section) {
-		try {
-			setIsFetching(true)
-			const { data: tasks = [] } = await client.tasks.searchTasksForWorkspace(
-				workspace,
-				{
-					'assignee.any': assignee,
-					'sections.any': section,
-					is_subtask: false,
-				}
-			)
+	const fetchTasks = useCallback(
+		async (workspace, assignee, section) => {
+			try {
+				setIsFetching(true)
+				const { data: tasks = [] } = await client.tasks.searchTasksForWorkspace(
+					workspace,
+					{
+						'assignee.any': assignee,
+						'sections.any': section,
+						is_subtask: false,
+					}
+				)
 
-			setTasks(tasks)
-		} catch (e) {
-			console.error(e)
-		} finally {
-			setIsFetching(false)
-		}
-	}
+				setTasks(tasks)
+			} catch (e) {
+				console.error(e)
+			} finally {
+				setIsFetching(false)
+			}
+		},
+		[client]
+	)
 
 	useEffect(() => {
-		if (!workspaceGid || !assigneeGid || !sectionGid || !client) return
+		if (!workspaceGid || !assigneeGid || !sectionGid) return
 
 		fetchTasks(workspaceGid, assigneeGid, sectionGid)
-	}, [workspaceGid, assigneeGid, sectionGid, client])
+	}, [workspaceGid, assigneeGid, sectionGid])
 
 	return { isFetching, tasks }
 }

--- a/client/src/hooks/asana/useUsersMe.js
+++ b/client/src/hooks/asana/useUsersMe.js
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useState } from 'react'
+import { useCallback, useContext, useEffect, useState } from 'react'
 import { ClientContext } from '../../contexts/ClientContext.js'
 
 export function useUsersMe() {
@@ -7,7 +7,7 @@ export function useUsersMe() {
 	const [isFetching, setIsFetching] = useState(false)
 	const { client } = useContext(ClientContext)
 
-	async function fetchUsersMe() {
+	const fetchUsersMe = useCallback(async () => {
 		try {
 			setIsFetching(true)
 			const { gid = '', workspaces = [] } = await client.users.me()
@@ -19,13 +19,11 @@ export function useUsersMe() {
 		} finally {
 			setIsFetching(false)
 		}
-	}
+	}, [client])
 
 	useEffect(() => {
-		if (!client) return
-
 		fetchUsersMe()
-	}, [client])
+	}, [])
 
 	return { isFetching, meGid, workspaces }
 }


### PR DESCRIPTION
目的
- 更新 task 的內容時，若 token 過期則自動 refresh token 並再 update 一次

調整
- 當更新 task 出現 401 (unauthorized) 則呼叫 `fetchOauthToken` 並再一次 `submitSuggestiveProportion`
- `fetchOauthToken` 由 Authorization 在 ClientContext provider 提供
- Authorization 加上 useRef 判斷 fetch user me 只需拿第一次就好，不必因為 client 的改動而重拿

重構
- Board 直接拿 ClientContext 取 user 的資料，避免多 fetch 一次 user me
- custom hook 取資料不必因為 client 的改動而重拿，改成 useCallback 與 client 相依但 useEffect 不用