### PR TITLE
Feat/access token refresher

### DIFF
--- a/client/src/components/oauth/Authorization.js
+++ b/client/src/components/oauth/Authorization.js
@@ -44,7 +44,7 @@ function Authorization({ children }) {
 		const handleRefreshAccessToken = accessTokenRefresher(
 			async refresh => {
 				await refresh()
-				setTimeout(fetchMe, 0)
+				setTimeout(fetchMe)
 			},
 			error => {
 				alert(error)

--- a/client/src/components/oauth/Authorization.js
+++ b/client/src/components/oauth/Authorization.js
@@ -78,7 +78,6 @@ function Authorization({ children }) {
 				client,
 				refreshToken,
 				user,
-				refreshAccessToken,
 				accessTokenRefresher,
 				resetClient,
 			}}

--- a/client/src/components/oauth/Authorization.js
+++ b/client/src/components/oauth/Authorization.js
@@ -32,10 +32,7 @@ function Authorization({ children }) {
 	const accessTokenRefresher = (resolve, reject) => async error => {
 		switch (error.status) {
 			case 401:
-				await refreshAccessToken()
-				setTimeout(() => {
-					resolve?.()
-				}, 0)
+				resolve?.(refreshAccessToken)
 				break
 			default:
 				reject?.(error)
@@ -45,8 +42,9 @@ function Authorization({ children }) {
 
 	const fetchMe = useCallback(async () => {
 		const handleRefreshAccessToken = accessTokenRefresher(
-			() => {
-				fetchMe()
+			async refresh => {
+				await refresh()
+				setTimeout(fetchMe, 0)
 			},
 			error => {
 				alert(error)

--- a/client/src/components/oauth/Authorization.js
+++ b/client/src/components/oauth/Authorization.js
@@ -44,7 +44,7 @@ function Authorization({ children }) {
 	}
 
 	const fetchMe = useCallback(async () => {
-		const refreshAccessToken = accessTokenRefresher(
+		const handleRefreshAccessToken = accessTokenRefresher(
 			() => {
 				fetchMe()
 			},
@@ -61,7 +61,7 @@ function Authorization({ children }) {
 			const { gid = '', name = '', email = '' } = await client.users.me()
 			setUser({ gid, name, email, isFetched: true })
 		} catch (error) {
-			await refreshAccessToken(error)
+			await handleRefreshAccessToken(error)
 		}
 	}, [client])
 
@@ -76,7 +76,14 @@ function Authorization({ children }) {
 
 	return (
 		<ClientContext.Provider
-			value={{ client, refreshToken, user, refreshAccessToken, resetClient }}
+			value={{
+				client,
+				refreshToken,
+				user,
+				refreshAccessToken,
+				accessTokenRefresher,
+				resetClient,
+			}}
 		>
 			{user.isFetched ? children : 'fetching...'}
 		</ClientContext.Provider>

--- a/client/src/hooks/asana/useSections.js
+++ b/client/src/hooks/asana/useSections.js
@@ -4,22 +4,18 @@ import { ClientContext } from '../../contexts/ClientContext.js'
 export function useSections({ projectGid }) {
 	const [sections, setSections] = useState([])
 	const [isFetching, setIsFetching] = useState(false)
-	const { client, refreshAccessToken } = useContext(ClientContext)
+	const { client, accessTokenRefresher } = useContext(ClientContext)
 
 	const fetchSections = useCallback(
 		async project => {
-			const handleRefreshAccessToken = async error => {
-				switch (error.status) {
-					case 401:
-						await refreshAccessToken()
-						setTimeout(() => {
-							fetchSections(project)
-						}, 0)
-						break
-					default:
-						console.error(error)
+			const handleRefreshAccessToken = accessTokenRefresher(
+				() => {
+					fetchSections(project)
+				},
+				error => {
+					console.error(error)
 				}
-			}
+			)
 
 			try {
 				setIsFetching(true)

--- a/client/src/hooks/asana/useSections.js
+++ b/client/src/hooks/asana/useSections.js
@@ -13,7 +13,7 @@ export function useSections({ projectGid }) {
 					await refresh()
 					setTimeout(() => {
 						fetchSections(project)
-					}, 0)
+					})
 				},
 				error => {
 					console.error(error)

--- a/client/src/hooks/asana/useSections.js
+++ b/client/src/hooks/asana/useSections.js
@@ -9,8 +9,11 @@ export function useSections({ projectGid }) {
 	const fetchSections = useCallback(
 		async project => {
 			const handleRefreshAccessToken = accessTokenRefresher(
-				() => {
-					fetchSections(project)
+				async refresh => {
+					await refresh()
+					setTimeout(() => {
+						fetchSections(project)
+					}, 0)
 				},
 				error => {
 					console.error(error)


### PR DESCRIPTION
目的
- 切換 tab 到 Board 頁面若 access token 過期，頁面會載入資料 401 失敗

處理
- 在第一支 `useSections` fetch 時處理 401 refresh access token

新增
- `accessTokenRefresh` 的 function，初始時傳入 `resolve` & `reject` functions 參數
  - `resolve` -> 401 發生時自定義如何利用 `refresh` 來更新
    - `setTimeout` 可幫助 updateClient 渲染後 fetch 使用正確的 client
  - `reject` -> 一般 `error` 發生時自義如何利用 error
- `useSections` 增加使用 `accessTokenRefresh` 來 refresh access token

重構
- `fetchMe` 使用的 hooks 優化
  - 改用 `accessTokenRefresh` 更新 token
  - useEffect 移除 client 的 dependency，避免過多 client 更新時一直重打
- `submitSuggestiveProportion` 使用的 hooks 優化
  - 改用 `accessTokenRefresh` 更新 token
  - 簡化 useRef, useState, useEffect 達到 refresh access token 的方式，改用 useRef `suspendedTasks` 即可