### PR TITLE
Fix/sub tasks missing

### DIFF
--- a/client/src/components/BoardTasks.js
+++ b/client/src/components/BoardTasks.js
@@ -58,11 +58,19 @@ function BoardTasks({ tasks }) {
 		}
 	}, [])
 	useEffect(() => {
-		const buttonList = detailTasks.map(task => ({
-			taskGid: task.gid,
+		const taskGidList = detailTasks.map(task => task.gid)
+		const buttonList = taskGidList.map(taskGid => ({
+			taskGid,
 			isLoading: false,
 		}))
-		const taskList = detailTasks.map(task => {
+		const taskList = detailTasks.reduce((taskList, task) => {
+			const parentGid = task.parent?.gid || ''
+			const isSubTask = taskGidList.includes(parentGid)
+
+			if (isSubTask) {
+				return taskList
+			}
+
 			const { startOn, dueOn } = (() => {
 				const { start_on: startOn, due_on: dueOn } = task
 				if (startOn && !dueOn) {
@@ -74,15 +82,17 @@ function BoardTasks({ tasks }) {
 				return { startOn, dueOn }
 			})()
 
-			return {
+			taskList.push({
 				gid: task.gid,
 				key: task.gid,
 				name: task.name,
 				startOn,
 				dueOn,
 				customField: getCustomField(task, CUSTOM_FIELD_GID),
-			}
-		})
+				parentGid: task.parent?.gid || '',
+			})
+			return taskList
+		}, [])
 
 		setButtonList(buttonList)
 		setTaskList(taskList)

--- a/client/src/hooks/asana/useTasks.js
+++ b/client/src/hooks/asana/useTasks.js
@@ -15,7 +15,6 @@ export function useTasks({ workspaceGid, assigneeGid, sectionGid }) {
 					{
 						'assignee.any': assignee,
 						'sections.any': section,
-						is_subtask: false,
 					}
 				)
 


### PR DESCRIPTION
目的
- 修正 task 列表顯示不完全的問題

原因
- 拿 section tasks 時加了 is_subtask `false` 參數

調整
- 將 is_subtask 參數拿掉，預設為 'true'
- 顯示 taskList 加上 parent 的過濾，若 parent 有出現則該 task 才不需要考慮