### PR TITLE
chore: no need REACT_APP_OAUTH_URL environment variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,6 @@ WORKDIR /app
 COPY package*.json .
 RUN npm install
 COPY ./client ./client
-ENV REACT_APP_OAUTH_URL=https://accounting-no-trouble.onrender.com
 RUN npm run build
 COPY . .
 EXPOSE 80

--- a/client/src/hooks/oauth/oauth.js
+++ b/client/src/hooks/oauth/oauth.js
@@ -1,8 +1,6 @@
-const baseUrl = process.env.REACT_APP_OAUTH_URL || ''
-
 export function fetchOauthAuthorize() {
 	return new Promise((resolve, reject) => {
-		fetch(`${baseUrl}/oauth/authorize`)
+		fetch('/oauth/authorize')
 			.then(response => response.text())
 			.then(url => resolve(url))
 			.catch(error => reject(error))
@@ -11,7 +9,7 @@ export function fetchOauthAuthorize() {
 
 function fetchOauthToken(body) {
 	return new Promise((resolve, reject) => {
-		fetch(`${baseUrl}/oauth/token`, {
+		fetch('/oauth/token', {
 			method: 'POST',
 			headers: {
 				'Content-Type': 'application/json',
@@ -48,7 +46,7 @@ export function fetchOauthTokenByRefreshToken(refreshToken) {
 
 export function fetchOauthRevoke(refreshToken) {
 	return new Promise((resolve, reject) => {
-		fetch(`${baseUrl}/oauth/revoke`, {
+		fetch('/oauth/revoke', {
 			method: 'POST',
 			headers: {
 				'Content-Type': 'application/json',


### PR DESCRIPTION
development
- package.json 有設定 proxy `http://localhost:3030` 可以自動代理 `http://localhost:3000`

production
- client 已 build 出來在 server 內，不需添加該環境變數，統一都是 `https://accounting-no-trouble.onrender.com`